### PR TITLE
Add support for specifying status codes to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ jQuery(function($) {
   $.ajax(options).retry({times:3, timeout:3000}).then(function(){
     alert("success!");
   });  
+
+  //this will only retry if the response status code matches the ones we specify
+  $.ajax(options).retry({times:3, statusCodes: [503, 504]}).then(function(){
+    alert("success!");
+  });
 });
 </script>
 ```

--- a/src/jquery.ajax-retry.js
+++ b/src/jquery.ajax-retry.js
@@ -14,6 +14,9 @@
       if(opts.timeout){
         this.timeout = opts.timeout;
       }
+      if (opts.statusCodes) {
+        this.statusCodes = opts.statusCodes;
+      }
       return this.pipe(null, pipeFailRetry(this, opts.times));
     };
   });
@@ -33,7 +36,7 @@
           .pipe(output.resolve, output.reject);
       }
 
-      if(times > 1){
+      if (times > 1 && (!jqXHR.statusCodes || $.inArray(input.status, jqXHR.statusCodes) > -1)) {
         // time to make that next request...
         if(jqXHR.timeout !== undefined){
           setTimeout(nextRequest, jqXHR.timeout);


### PR DESCRIPTION
We needed a way to retry only on specific status codes, so we extended the library to support this use case.

I've added some tests for this. We'd love to get this changes upstream since your library has provided very helpful.

What do you think?

Cheers
