### PR TITLE
v0.2.2: Add manifest file for jQuery Plugins Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.gcno
 *.gcda
 *.gcov
+
+# npm modules
+node_modules

--- a/ajax-retry.jquery.json
+++ b/ajax-retry.jquery.json
@@ -1,0 +1,36 @@
+{
+  "name": "ajax-retry",
+  "title": "jQuery Ajax Retry",
+  "description": "Retry ajax calls using the deferred API",
+  "keywords": [
+    "ajax",
+    "retry"
+  ],
+  "version": "0.2.2",
+  "author": {
+    "name": "John Paul",
+    "email": "john@johnkpaul.com",
+    "url": "http://www.johnkpaul.com"
+  },
+  "maintainers": [
+    {
+      "name": "John Paul",
+      "email": "john@johnkpaul.com",
+      "url": "http://www.johnkpaul.com"
+    }
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/johnkpaul/jquery-ajax-retry/blob/0.2.2/LICENSE-MIT"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/johnkpaul/jquery-ajax-retry/issues"
+  },
+  "homepage": "https://github.com/johnkpaul/jquery-ajax-retry",
+  "docs": "https://github.com/johnkpaul/jquery-ajax-retry",
+  "dependencies": {
+    "jquery": ">=1.5"
+  }
+}

--- a/dist/jquery.ajax-retry.js
+++ b/dist/jquery.ajax-retry.js
@@ -1,6 +1,6 @@
-/*! jQuery Ajax Retry - v0.2.0 - 2012-09-28
+/*! jQuery Ajax Retry - v0.2.2 - 2013-02-05
 * https://github.com/johnkpaul/jquery-ajax-retry
-* Copyright (c) 2012 John Paul; Licensed MIT */
+* Copyright (c) 2013 John Paul; Licensed MIT */
 
 (function($) {
 

--- a/dist/jquery.ajax-retry.min.js
+++ b/dist/jquery.ajax-retry.min.js
@@ -1,4 +1,4 @@
-/*! jQuery Ajax Retry - v0.2.0 - 2012-09-28
+/*! jQuery Ajax Retry - v0.2.2 - 2013-02-05
 * https://github.com/johnkpaul/jquery-ajax-retry
-* Copyright (c) 2012 John Paul; Licensed MIT */
-(function(a){function b(b,c){return function(d,e,f){function i(){a.ajax(g).retry({times:c-1}).pipe(h.resolve,h.reject)}var g=this,h=new a.Deferred;return c>1?b.timeout!==undefined?setTimeout(i,b.timeout):i():h.rejectWith(this,arguments),h}}a.ajaxPrefilter(function(a,c,d){d.retry=function(a){return a.timeout&&(this.timeout=a.timeout),this.pipe(null,b(this,a.times))}})})(jQuery);
+* Copyright (c) 2013 John Paul; Licensed MIT */
+(function(e){function t(t,n){return function(r,i,s){function a(){e.ajax(o).retry({times:n-1}).pipe(u.resolve,u.reject)}var o=this,u=new e.Deferred;return n>1?t.timeout!==undefined?setTimeout(a,t.timeout):a():u.rejectWith(this,arguments),u}}e.ajaxPrefilter(function(e,n,r){r.retry=function(e){return e.timeout&&(this.timeout=e.timeout),this.pipe(null,t(this,e.times))}})})(jQuery);

--- a/grunt.js
+++ b/grunt.js
@@ -55,6 +55,28 @@ module.exports = function(grunt) {
   });
 
   // Default task.
-  grunt.registerTask('default', 'lint qunit concat min');
+  grunt.registerTask('default', 'lint qunit concat min manifest');
 
+  grunt.registerTask( "manifest", function() {
+    var pkg = grunt.config( "pkg" );
+    grunt.file.write( "ajax-retry.jquery.json", JSON.stringify({
+      name: "ajax-retry",
+      title: pkg.title,
+      description: pkg.description,
+      keywords: pkg.keywords,
+      version: pkg.version,
+      author: pkg.author,
+      maintainers: pkg.maintainers,
+      licenses: pkg.licenses.map(function( license ) {
+        license.url = license.url.replace( "master", pkg.version );
+        return license;
+      }),
+      bugs: pkg.bugs,
+      homepage: pkg.homepage,
+      docs: pkg.homepage,
+      dependencies: {
+        jquery: ">=1.5"
+      }
+    }, null, "  " ) );
+  });
 };

--- a/package.json
+++ b/package.json
@@ -2,13 +2,18 @@
   "name": "jquery.ajax-retry",
   "title": "jQuery Ajax Retry",
   "description": "Retry ajax calls using the deferred API",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/johnkpaul/jquery-ajax-retry",
   "author": {
     "name": "John Paul",
     "email": "john@johnkpaul.com",
     "url": "http://www.johnkpaul.com"
   },
+  "maintainers": [{
+    "name": "John Paul",
+    "email": "john@johnkpaul.com",
+    "url": "http://www.johnkpaul.com"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/johnkpaul/jquery-ajax-retry.git"
@@ -28,5 +33,5 @@
   "devDependencies": {
     "grunt": "~0.3.15"
   },
-  "keywords": []
+  "keywords": [ "ajax", "retry" ]
 }


### PR DESCRIPTION
Step 1:

Setup a webhook on https://github.com/johnkpaul/jquery-ajax-retry/admin/hooks to point at `http://plugins.jquery.com/postreceive-hook`

Step 2:

Merge this

Step 3:

Tag the repo 0.2.2 and `git push --tags`
