### PR TITLE
inc jquery dependency version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   ],
   "dependencies": {
-    "jquery": "~1.5",
+    "jquery": "~2.1",
     "grunt-contrib-qunit": "~0.5.1",
     "grunt-contrib-concat": "~0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
       "url": "https://github.com/johnkpaul/jquery-ajax-retry/blob/master/LICENSE-MIT"
     }
   ],
+  "peerDependencies": {
+    "jquery": ">=1.5"
+  },
   "dependencies": {
-    "jquery": "~2.1",
     "grunt-contrib-qunit": "~0.5.1",
     "grunt-contrib-concat": "~0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery.ajax-retry",
   "title": "jQuery Ajax Retry",
   "description": "Retry ajax calls using the deferred API",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "homepage": "https://github.com/johnkpaul/jquery-ajax-retry",
   "author": {
     "name": "John Paul",


### PR DESCRIPTION
Because when installed via npm,  old jquery points to a JSDOM version
of jquery. Which is not what we want to have. In the later versions it
has been changed.
