### PR TITLE
move not necessary dependences to devDependences

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "jquery": ">=1.5"
   },
   "dependencies": {
-    "grunt-contrib-qunit": "~0.5.1",
-    "grunt-contrib-concat": "~0.4.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
     "load-grunt-tasks": "~0.5.0",
+    "grunt-contrib-qunit": "~0.5.1",
+    "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0"
   },


### PR DESCRIPTION
now it installs a lot heavy deps (phantomjs for example), but they are needed only for dev.
